### PR TITLE
feat: add version flag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,13 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags: |
+      -X github.com/prometheus/common/version.BuildDate={{.Date}}
+      -X github.com/prometheus/common/version.BuildUser=goreleaser
+      -X github.com/prometheus/common/version.Revision={{.FullCommit}}
+      -X github.com/prometheus/common/version.Branch={{.Branch}}
+      -X github.com/prometheus/common/version.Version={{.Version}}
+      -X main.version={{.Version}}
 nfpms:
 - maintainer: Roald Nefs <info@roaldnefs.com>
   description: Prometheus exporter for MessageBird metrics.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Flags:
               Path under which to expose metrics.
       --messagebird.api-key=MESSAGEBIRD.API-KEY  
               MessageBird Api Key.
+      --version  Show application version.
 
 $ messagebird_exporter --messagebird.api-key=test_myapikey
 INFO[0000] Starting MessageBird Exporter                 version=unknown

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/messagebird/go-rest-api v5.3.0+incompatible
 	github.com/prometheus/client_golang v1.9.0
+	github.com/prometheus/common v0.15.0
 	github.com/sirupsen/logrus v1.7.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/messagebird_exporter.go
+++ b/messagebird_exporter.go
@@ -12,6 +12,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/prometheus/common/version"
+
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	log "github.com/sirupsen/logrus"
@@ -64,6 +66,8 @@ func main() {
 		).Required().String()
 	)
 
+	kingpin.Version(version.Print("messagebird_exporter"))
+
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 
@@ -72,10 +76,11 @@ func main() {
 
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(credits)
+	registry.MustRegister(version.NewCollector("messagebird_exporter"))
 	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 
 	log.WithFields(log.Fields{
-		"version": "unknown",
+		"version": version.Version,
 	}).Info("Starting MessageBird Exporter")
 
 	recordMetrics()


### PR DESCRIPTION
Add version flag and set LDFLAGS in goreleaser configuration to specify the version information on new builds.

Example version information:
```
messagebird_exporter, version 0.1.0 (branch: feat/add-version-information, revision: a3a4f2318e8e558ad84d632187cf0bda4311e782)
  build user:       goreleaser
  build date:       2023-01-27T21:26:00Z
  go version:       go1.19.4
  platform:         darwin/amd64
```

Fixes #2 